### PR TITLE
feat: use benchmark iteration loop to measure logger performance

### DIFF
--- a/Benchmarks/LoggingBenchmark/Logging.swift
+++ b/Benchmarks/LoggingBenchmark/Logging.swift
@@ -6,17 +6,23 @@ import Logging
 
 @_dynamicReplacement(for: registerBenchmarks)
 func benchmarks() {
-    Benchmark("Logging without metadata provider") { benchmark in
-        print(benchmark.thresholds ?? "No threshholds")
+    Benchmark("Logging without metadata provider",
+              throughputScalingFactor: .mega,
+              desiredDuration: .seconds(3)
+    ) { benchmark in
         var logger = Logger(label: "benchmark", factory: SwiftLogNoOpLogHandler.init)
         logger.logLevel = .trace
 
         benchmark.startMeasurement()
-        logger.trace("Example log message", metadata: ["ad-hoc": "42"])
+        for _ in benchmark.throughputIterations {
+            logger.trace("Example log message", metadata: ["ad-hoc": "42"])
+        }
     }
 
     Benchmark(
         "Logging with metadata provider and task-local baggage",
+        throughputScalingFactor: .mega,
+        desiredDuration: .seconds(3),
         thresholds: [
             .wallClock: .init(relative: [.p99: 50])
         ]
@@ -31,7 +37,9 @@ func benchmarks() {
         let baggage = Baggage.topLevel
         Baggage.$current.withValue(baggage) {
             benchmark.startMeasurement()
-            logger.trace("Example log message", metadata: ["ad-hoc": "42"])
+            for _ in benchmark.throughputIterations {
+                logger.trace("Example log message", metadata: ["ad-hoc": "42"])
+            }
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing-baggage", from: "0.3.0"),
-        .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/ordo-one/package-benchmark", .upToNextMajor(from: "0.4.1")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Correct benchmark loop, execute the logger function for 1 million times, and run the test for 3 seconds.